### PR TITLE
unexport Macaroon class

### DIFF
--- a/test/discharge.js
+++ b/test/discharge.js
@@ -6,7 +6,7 @@ const m = require('../macaroon');
 const testUtils = require('./test-utils');
 
 test('should discharge a macaroon with no caveats without calling getDischarge', t => {
-  const macaroon = new m.Macaroon({
+  const macaroon = m.newMacaroon({
     rootKey: testUtils.strUint8Array('key'),
     identifier: 'some id',
     location: 'a location'
@@ -30,7 +30,7 @@ test('should discharge a macaroon with no caveats without calling getDischarge',
 test('should discharge many discharges correctly', t => {
   const rootKey = testUtils.strUint8Array('secret');
   const queued = [];
-  const m0 = new m.Macaroon({
+  const m0 = m.newMacaroon({
     rootKey,
     identifier: 'id0',
     location: 'location0'
@@ -53,10 +53,9 @@ test('should discharge many discharges correctly', t => {
   addCaveats(m0);
   const getDischarge = function (loc, thirdPartyLoc, cond, onOK, onErr) {
     t.equal(loc, 'location0');
-    const macaroon = new m.Macaroon({
+    const macaroon = m.newMacaroon({
       rootKey: testUtils.strUint8Array('root key ' + cond),
-      identifier: cond,
-      location: ''});
+      identifier: cond});
     addCaveats(macaroon);
     queued.push(() => {
       onOK(macaroon);

--- a/test/import-export.js
+++ b/test/import-export.js
@@ -21,14 +21,14 @@ test('should import from a single object', t => {
     ],
   };
 
-  const macaroon = m.generateMacaroons(obj);
+  const macaroon = m.importFromJSONObject(obj);
   t.equal(macaroon.location, 'a location');
   t.equal(macaroon.identifier, 'id 1');
   t.equal(
     testUtils.Uint8ArrayToHex(macaroon.signature),
     'e0831c334c600631bf7b860ca20c9930f584b077b8eac1f1e99c6a45d11a3d20');
   // Test that it round trips.
-  const obj1 = macaroon.exportAsObject();
+  const obj1 = macaroon.exportAsJSONObject();
   t.deepEqual(obj1, obj);
   t.end();
 });
@@ -38,20 +38,19 @@ test('should import from an array', t => {
     location: 'a location',
     identifier: 'id 0',
     signature: '4579ad730bf3f819a299aaf63f04f5e897d80690c4c5814a1ae026a45989de7d',
-    caveats: [],
   }, {
     location: 'a location',
     identifier: 'id 1',
     signature: '99b1c2dede0ce1cba0b632e3996e9924bdaee6287151600468644b92caf3761b',
-    caveats: [],
   }];
-  const macaroon = m.generateMacaroons(objs);
+  const macaroon = m.importFromJSONObject(objs);
+  
   t.equal(macaroon.length, 2);
   t.equal(macaroon[0].identifier, 'id 0');
   t.equal(macaroon[1].identifier, 'id 1');
 
   t.deepEqual([
-    macaroon[0].exportAsObject(),
-    macaroon[1].exportAsObject()], objs);
+    macaroon[0].exportAsJSONObject(),
+    macaroon[1].exportAsJSONObject()], objs);
   t.end();
 });

--- a/test/macaroon.js
+++ b/test/macaroon.js
@@ -7,7 +7,7 @@ const testUtils = require('./test-utils');
 
 test('should be created with the expected signature', t => {
   const rootKey = testUtils.strUint8Array('secret');
-  const macaroon = new m.Macaroon({
+  const macaroon = m.newMacaroon({
     rootKey,
     identifier: 'some id',
     location: 'a location'
@@ -18,12 +18,11 @@ test('should be created with the expected signature', t => {
     testUtils.Uint8ArrayToHex(macaroon.signature),
     'd916ce6f9b62dc4a080ce5d4a660956471f19b860da4242b0852727331c1033d');
 
-  const obj = macaroon.exportAsObject();
+  const obj = macaroon.exportAsJSONObject();
   t.deepEqual(obj, {
     location: 'a location',
     identifier: 'some id',
     signature: 'd916ce6f9b62dc4a080ce5d4a660956471f19b860da4242b0852727331c1033d',
-    caveats: [],
   });
 
   macaroon.verify(rootKey, testUtils.never);
@@ -32,11 +31,11 @@ test('should be created with the expected signature', t => {
 
 test('should fail when newMacaroon called with bad args', t => {
   t.throws(() => {
-    new m.Macaroon({
+    m.newMacaroon({
       rootKey: null, identifier: 'some id', location: 'a location'});
   }, 'Macaroon root key, is not of type Uint8Array.');
   t.throws(() => {
-    new m.Macaroon({
+    m.newMacaroon({
       rootKey: 'invalid', identifier: 'some id', location: 'a location'});
   }, 'Macaroon root key, is not of type Uint8Array.');
   t.throws(() => {
@@ -45,30 +44,30 @@ test('should fail when newMacaroon called with bad args', t => {
 
   var key = testUtils.strUint8Array('key');
   t.throws(() => {
-    new m.Macaroon(key, null, 'a location');
+    m.newMacaroon(key, null, 'a location');
   }, 'Macaroon identifier, is not of type string.');
   t.throws(() => {
-    new m.Macaroon(key, 5, 'a location');
+    m.newMacaroon(key, 5, 'a location');
   }, 'Macaroon identifier, is not of type string.');
   t.throws(() => {
-    new m.Macaroon(key, key, 'a location');
+    m.newMacaroon(key, key, 'a location');
   }, 'Macaroon identifier, is not of type string.');
 
   t.throws(() => {
-    new m.Macaroon(key, 'id', null);
+    m.newMacaroon(key, 'id', null);
   }, 'Macaroon location, is not of type string.');
   t.throws(() => {
-    new m.Macaroon(key, 'id', 5);
+    m.newMacaroon(key, 'id', 5);
   }, 'Macaroon location, is not of type string.');
   t.throws(() => {
-    new m.Macaroon(key, 'id', key);
+    m.newMacaroon(key, 'id', key);
   }, 'Macaroon location, is not of type string.');
   t.end();
 });
 
 test('should allow adding first party caveats', t => {
   const rootKey = testUtils.strUint8Array('secret');
-  const macaroon = new m.Macaroon({
+  const macaroon = m.newMacaroon({
     rootKey,
     identifier: 'some id',
     location: 'a location'
@@ -83,7 +82,7 @@ test('should allow adding first party caveats', t => {
   t.equal(
     testUtils.Uint8ArrayToHex(macaroon.signature),
     'c934e6af642ee55a4e4cfc56e07706cf1c6c94dc2192e5582943cddd88dc99d8');
-  const obj = macaroon.exportAsObject();
+  const obj = macaroon.exportAsJSONObject();
   t.deepEqual(obj, {
     location: 'a location',
     identifier: 'some id',
@@ -114,19 +113,22 @@ test('should allow adding first party caveats', t => {
 
 test('should allow adding a third party caveat', t => {
   const rootKey = testUtils.strUint8Array('secret');
-  const macaroon = new m.Macaroon({
-    rootKey, identifier: 'some id', location: 'a location'
+  const macaroon = m.newMacaroon({
+    rootKey,
+    identifier: 'some id',
+    location: 'a location',
   });
   const dischargeRootKey = testUtils.strUint8Array('shared root key');
   const thirdPartyCaveatId = '3rd party caveat';
   macaroon.addThirdPartyCaveat(
     dischargeRootKey, thirdPartyCaveatId, 'remote.com');
 
-  const dm = new m.Macaroon({
+  const dm = m.newMacaroon({
     rootKey: dischargeRootKey,
     identifier: thirdPartyCaveatId,
-    location: 'remote location'
+    location: 'remote location',
   });
+
   dm.bind(macaroon.signature);
   macaroon.verify(rootKey, testUtils.never, [dm]);
   t.end();
@@ -134,7 +136,7 @@ test('should allow adding a third party caveat', t => {
 
 test('should allow binding to another macaroon', t => {
   const rootKey = testUtils.strUint8Array('secret');
-  const macaroon = new m.Macaroon({
+  const macaroon = m.newMacaroon({
     rootKey, identifier: 'some id', location: 'a location'
   });
   const otherSig = testUtils.strUint8Array('another sig');

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -43,7 +43,7 @@ module.exports.makeMacaroons = mspecs => {
     if (mspec.location === undefined) {
       mspec.location = '';
     }
-    const macaroon = new m.Macaroon({
+    const macaroon = m.newMacaroon({
       rootKey: strUint8Array(mspec.rootKey),
       identifier: mspec.id,
       location: mspec.location

--- a/test/verify.js
+++ b/test/verify.js
@@ -446,7 +446,7 @@ const externalMacaroons = [
 ];
 
 test('should verify external third party macaroons correctly', t => {
-  const ms = m.generateMacaroons(externalMacaroons);
+  const ms = m.importFromJSONObject(externalMacaroons);
   ms[0].verify(externalRootKey, () => {}, ms.slice(1));
   t.end();
 });


### PR DESCRIPTION
Change the single constructor to something we only
use internally and provide newMacaroon and importFromJSONObject
functions that construct macaroons using the internal constructor.

Also rename js-macaroon.js to macaroon.js, add LICENSE
file and reorder package.json attributes in preparation for merge
with original js-macaroon branch.