### PR TITLE
feat: support v2 serialization

### DIFF
--- a/macaroon.js
+++ b/macaroon.js
@@ -353,7 +353,7 @@ const Macaroon = class Macaroon {
       const caveatObj = {
         i: caveat._identifier
       };
-      if (caveat._vid !== null) {
+      if (!!caveat._vid) {
         // Use URL encoding and do not append "=" characters.
         caveatObj.v64 = sjcl.codec.base64.fromBits(caveat._vid, true, true);
         caveatObj.l = caveat._location;
@@ -455,7 +455,7 @@ const Macaroon = class Macaroon {
     let caveatSig = keyedHash(
       rootKey, sjcl.codec.utf8String.toBits(this.identifier));
     this._caveats.forEach(caveat => {
-      if (caveat._vid !== null) {
+      if (!!caveat._vid) {
         const cavKey = decrypt(caveatSig, caveat._vid);
         let found = false;
         let di, dm;
@@ -617,9 +617,9 @@ const deserializeBinary = function(serializedMacaroon) {
   const caveats = [];
   if (buf.readUInt8(offset) !== 0) {
     while (offset < buf.length) {
-      let caveatLocation;
       let caveatIdentifier;
-      let caveatVid;
+      let caveatLocation = null;
+      let caveatVid = null;
       const caveatLocationOrIdentifier = readTypeLengthValue(buf, offset);
       if (caveatLocationOrIdentifier.type === V2_TYPES.LOCATION) {
         caveatLocation = caveatLocationOrIdentifier.value.toString();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "sjcl": "^1.0.6",
     "tweetnacl": "^0.14.5",
-    "tweetnacl-util": "^0.15.0"
+    "tweetnacl-util": "^0.15.0",
+    "varint": "^5.0.0"
   },
   "description": "Macaroons: cookies with contextual caveats for decentralized authorization in the cloud.",
   "devDependencies": {

--- a/test/serialize-binary.js
+++ b/test/serialize-binary.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const test = require('tape');
+const sjcl = require('sjcl');
+
+const m = require('../macaroon');
+
+test('should serialize binary format without caveats', t => {
+  const macaroon = m.newMacaroon({
+    rootKey: Buffer.from('this is the key'),
+    identifier: 'keyid',
+    location: 'http://example.org/'
+  });
+
+  t.equal(macaroon.serializeBinary().toString('base64'), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
+  t.end();
+});
+
+test('should serialize binary format with one caveat', t => {
+  const macaroon = m.newMacaroon({
+    rootKey: Buffer.from('this is the key'),
+    identifier: 'keyid',
+    location: 'http://example.org/'
+  });
+  macaroon.addFirstPartyCaveat('account = 3735928559');
+
+  t.equal(macaroon.serializeBinary().toString('base64'), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw==');
+  t.end();
+});
+
+test('should serialize binary format with two caveats', t => {
+  const macaroon = m.newMacaroon({
+    rootKey: Buffer.from('this is the key'),
+    identifier: 'keyid',
+    location: 'http://example.org/'
+  });
+  macaroon.addFirstPartyCaveat('account = 3735928559');
+  macaroon.addFirstPartyCaveat('user = alice');
+
+  t.equal(macaroon.serializeBinary().toString('base64'), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe/A==');
+  t.end();
+});
+
+test('should deserialize binary format without caveats', t => {
+  const macaroon = m.deserializeBinary('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
+  t.equal(macaroon._location, 'http://example.org/');
+  t.equal(macaroon._identifier, 'keyid');
+  t.equal(macaroon._caveats.length, 0);
+  t.equals(sjcl.codec.base64.fromBits(macaroon._signature), 'fN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
+  t.end();
+});
+
+test('should deserialize binary format with one caveat', t => {
+  const macaroon = m.deserializeBinary('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw==');
+  t.equal(macaroon._location, 'http://example.org/');
+  t.equal(macaroon._identifier, 'keyid');
+  t.equal(macaroon._caveats.length, 1);
+  t.equal(macaroon._caveats[0]._identifier, 'account = 3735928559');
+  t.ok(Buffer.from(sjcl.codec.base64.fromBits(macaroon._signature), 'base64').equals(Buffer.from('9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc', 'base64')));
+  t.end();
+});
+
+test('should deserialize binary format with two caveats', t => {
+  const macaroon = m.deserializeBinary('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe/A==');
+  t.equal(macaroon._location, 'http://example.org/');
+  t.equal(macaroon._identifier, 'keyid');
+  t.equal(macaroon._caveats.length, 2);
+  t.equal(macaroon._caveats[0]._identifier, 'account = 3735928559');
+  t.equal(macaroon._caveats[1]._identifier, 'user = alice');
+  t.ok(Buffer.from(sjcl.codec.base64.fromBits(macaroon._signature), 'base64').equals(Buffer.from('S+lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw=', 'base64')));
+  t.end();
+});

--- a/test/serialize-json.js
+++ b/test/serialize-json.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const test = require('tape');
+const sjcl = require('sjcl');
+
+const m = require('../macaroon');
+
+test('should serialize json format without caveats', t => {
+  const macaroon = m.newMacaroon({
+    rootKey: Buffer.from('this is the key'),
+    identifier: 'keyid',
+    location: 'http://example.org/'
+  });
+
+  t.deepEqual(macaroon.serializeJson(), {'v':2,'l':'http://example.org/','i':'keyid','c':[],'s64':'fN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc'});
+  t.end();
+});
+
+test('should serialize json format with one caveat', t => {
+  const macaroon = m.newMacaroon({
+    rootKey: Buffer.from('this is the key'),
+    identifier: 'keyid',
+    location: 'http://example.org/'
+  });
+  macaroon.addFirstPartyCaveat('account = 3735928559');
+
+  t.deepEqual(macaroon.serializeJson(), {'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'}],'s64':'9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc'});
+  t.end();
+});
+
+test('should serialize json format with two caveats', t => {
+  const macaroon = m.newMacaroon({
+    rootKey: Buffer.from('this is the key'),
+    identifier: 'keyid',
+    location: 'http://example.org/'
+  });
+  macaroon.addFirstPartyCaveat('account = 3735928559');
+  macaroon.addFirstPartyCaveat('user = alice');
+
+  t.deepEqual(macaroon.serializeJson(), {'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'},{'i':'user = alice'}],'s64':'S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw'});
+  t.end();
+});
+
+test('should deserialize json format without caveats', t => {
+  const macaroon = m.deserializeJson({'v':2,'l':'http://example.org/','i':'keyid','c':[],'s64':'fN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc'});
+  t.equal(macaroon._location, 'http://example.org/');
+  t.equal(macaroon._identifier, 'keyid');
+  t.equal(macaroon._caveats.length, 0);
+  t.equal(sjcl.codec.base64.fromBits(macaroon._signature), 'fN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
+  t.end();
+});
+
+test('should deserialize json format with one caveat', t => {
+  const macaroon = m.deserializeJson({'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'}],'s64':'9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc'});
+  t.equal(macaroon._location, 'http://example.org/');
+  t.equal(macaroon._identifier, 'keyid');
+  t.equal(macaroon._caveats.length, 1);
+  t.equal(macaroon._caveats[0]._identifier, 'account = 3735928559');
+  t.ok(Buffer.from(sjcl.codec.base64.fromBits(macaroon._signature), 'base64').equals(Buffer.from('9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc', 'base64')));
+  t.end();
+});
+
+test('should deserialize json format with two caveats', t => {
+  const macaroon = m.deserializeJson({'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'},{'i':'user = alice'}],'s64':'S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw'});
+  t.equal(macaroon._location, 'http://example.org/');
+  t.equal(macaroon._identifier, 'keyid');
+  t.equal(macaroon._caveats.length, 2);
+  t.equal(macaroon._caveats[0]._identifier, 'account = 3735928559');
+  t.equal(macaroon._caveats[1]._identifier, 'user = alice');
+  t.ok(Buffer.from(sjcl.codec.base64.fromBits(macaroon._signature), 'base64').equals(Buffer.from('S+lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw=', 'base64')));
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -5,3 +5,4 @@ require('./import-export');
 require('./verify');
 require('./discharge');
 require('./serialize-binary');
+require('./serialize-json');

--- a/test/test.js
+++ b/test/test.js
@@ -4,3 +4,4 @@ require('./macaroon');
 require('./import-export');
 require('./verify');
 require('./discharge');
+require('./serialize-binary');


### PR DESCRIPTION
Adds support for official macaroon v2 binary and json serialization, as defined [here](https://github.com/rescrv/libmacaroons/blob/0cc39f4e990955ac0885f3f7be3500151d4e7e45/doc/format.txt).