### PR TITLE
binary serialization changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,15 @@
     "Jeff Pihach (https://fromanegg.com)"
   ],
   "dependencies": {
+    "base64-js": "^1.2.1",
+    "benchmark": "^2.1.4",
+    "microtime": "^2.1.6",
+    "rewire": "^2.5.2",
     "sjcl": "^1.0.6",
+    "text-encoding": "^0.6.4",
     "tweetnacl": "^0.14.5",
     "tweetnacl-util": "^0.15.0",
-    "varint": "^5.0.0"
+    "uglifyjs": "^2.4.11"
   },
   "description": "Macaroons: cookies with contextual caveats for decentralized authorization in the cloud.",
   "devDependencies": {

--- a/test/internal.js
+++ b/test/internal.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const rewire = require('rewire');
+const test = require('tape');
+
+const m = rewire('../macaroon');
+const testUtils = require('./test-utils');
+const bytes = testUtils.bytes;
+
+const ByteBuffer = m.__get__('ByteBuffer');
+const ByteReader = m.__get__('ByteReader');
+
+
+test('ByteBuffer append single byte', t => {
+  const buf = new ByteBuffer(0);
+  buf.appendByte(123);
+  t.equal(buf.bytes.toString(), '123');
+  t.end();
+});
+
+test('ByteBuffer append 10 bytes byte', t => {
+  const buf = new ByteBuffer(0);
+  for(var i = 0; i < 10; i++) {
+    buf.appendByte(i);
+  }
+  t.equal(buf.bytes.toString(), '0,1,2,3,4,5,6,7,8,9');
+  t.end();
+});
+
+test('ByteBuffer append bytes', t => {
+  const buf = new ByteBuffer(0);
+  buf.appendBytes(bytes([3,1,4,1,5,9,3]));
+  t.equal(buf.bytes.toString(), '3,1,4,1,5,9,3');
+  t.end();
+});
+
+const varintTests = [
+  [2147483648, [128, 128, 128, 128, 8]],
+  [2147483649, [129, 128, 128, 128, 8]],
+  [4294967295, [255, 255, 255, 255, 15]],
+  [0, [0]],
+  [1, [1]],
+  [2, [2]],
+  [10, [10]],
+  [20, [20]],
+  [63, [63]],
+  [64, [64]],
+  [65, [65]],
+  [127, [127]],
+  [128, [128, 1]],
+  [129, [129, 1]],
+  [255, [255, 1]],
+  [256, [128, 2]],
+  [257, [129, 2]],
+  [2147483647, [255, 255, 255, 255, 7]],
+];
+
+test('ByteBuffer appendUvarint', t => {
+  varintTests.forEach(test => {
+    const buf = new ByteBuffer(0);
+    buf.appendUvarint(test[0]);
+    t.deepEqual(buf.bytes, test[1], `test ${test[0]}`);
+  });
+  t.end();
+});
+
+test('ByteReader read byte', t => {
+  const r = new ByteReader(bytes([0, 1, 2, 3]));
+  t.equal(r.length, 4);
+  for(var i = 0; i < 4; i++) {
+    t.equal(r.readByte(), i, `byte ${i}`);
+  }
+  t.throws(function() {
+    r.readByte();
+  }, RangeError);
+  t.end();
+});
+
+test('ByteReader read bytes', t => {
+  const r = new ByteReader(bytes([0, 1, 2, 3, 4, 5]));
+  t.equal(r.readByte(), 0);
+  t.deepEqual(r.readN(3), bytes([1,2,3]));
+  t.throws(function() {
+    r.readN(3);
+  }, RangeError);
+  t.end();
+});
+
+test('ByteReader readUvarint', t => {
+  varintTests.forEach(test => {
+    const r = new ByteReader(bytes([99].concat(test[1])));
+    // Read one byte at the start so we are dealing with a non-zero
+    // index.
+    r.readByte();
+    const len0 = r.length;
+    const x = r.readUvarint();
+    t.equal(x, test[0], `test ${test[0]}`);
+    // Check that we've read the expected number of bytes.
+    t.equal(len0 - r.length, test[1].length);
+  });
+  t.end();
+});
+
+test('ByteReader readUvarint out of bounds', t => {
+  const r = new ByteReader(bytes([]));
+  t.throws(function() {
+    r.readUvarint();
+  }, RangeError);
+  // Try all the tests with one less byte than there should be.
+  varintTests.forEach(test => {
+    const r = new ByteReader(test[1].slice(0, test[1].length-1));
+    t.throws(function() {
+      r.readUvarint();
+    }, RangeError);
+  });
+  t.end();
+});

--- a/test/serialize-binary.js
+++ b/test/serialize-binary.js
@@ -1,9 +1,12 @@
 'use strict';
 
 const test = require('tape');
-const sjcl = require('sjcl');
+const testUtils = require('./test-utils');
 
 const m = require('../macaroon');
+
+const base64ToBytes = testUtils.base64ToBytes;
+const bytesToBase64 = testUtils.bytesToBase64;
 
 test('should serialize binary format without caveats', t => {
   const macaroon = m.newMacaroon({
@@ -12,19 +15,19 @@ test('should serialize binary format without caveats', t => {
     location: 'http://example.org/'
   });
 
-  t.equal(macaroon.serializeBinary().toString('base64'), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
+  t.equal(bytesToBase64(macaroon.serializeBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
   t.end();
 });
 
 test('should serialize binary format with one caveat', t => {
+  console.log('test: should serialize binary format with one caveat');
   const macaroon = m.newMacaroon({
     rootKey: Buffer.from('this is the key'),
     identifier: 'keyid',
     location: 'http://example.org/'
   });
   macaroon.addFirstPartyCaveat('account = 3735928559');
-
-  t.equal(macaroon.serializeBinary().toString('base64'), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw==');
+  t.equal(bytesToBase64(macaroon.serializeBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw==');
   t.end();
 });
 
@@ -37,36 +40,36 @@ test('should serialize binary format with two caveats', t => {
   macaroon.addFirstPartyCaveat('account = 3735928559');
   macaroon.addFirstPartyCaveat('user = alice');
 
-  t.equal(macaroon.serializeBinary().toString('base64'), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe/A==');
+  t.equal(bytesToBase64(macaroon.serializeBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe/A==');
   t.end();
 });
 
 test('should deserialize binary format without caveats', t => {
-  const macaroon = m.deserializeBinary('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
-  t.equal(macaroon._location, 'http://example.org/');
-  t.equal(macaroon._identifier, 'keyid');
+  const macaroon = m.deserializeBinary(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc='));
+  t.equal(macaroon.location, 'http://example.org/');
+  t.equal(macaroon.identifier, 'keyid');
   t.equal(macaroon._caveats.length, 0);
-  t.equals(sjcl.codec.base64.fromBits(macaroon._signature), 'fN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
+  t.equals(bytesToBase64(macaroon.signature), 'fN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc=');
   t.end();
 });
 
 test('should deserialize binary format with one caveat', t => {
-  const macaroon = m.deserializeBinary('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw==');
+  const macaroon = m.deserializeBinary(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw=='));
   t.equal(macaroon._location, 'http://example.org/');
   t.equal(macaroon._identifier, 'keyid');
   t.equal(macaroon._caveats.length, 1);
   t.equal(macaroon._caveats[0]._identifier, 'account = 3735928559');
-  t.ok(Buffer.from(sjcl.codec.base64.fromBits(macaroon._signature), 'base64').equals(Buffer.from('9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc', 'base64')));
+  t.equal(bytesToBase64(macaroon.signature), '9UgH9txu34i/D3MGs4IlYqNiUz2/czm6YXZdpL0lnYc=');
   t.end();
 });
 
 test('should deserialize binary format with two caveats', t => {
-  const macaroon = m.deserializeBinary('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe/A==');
+  const macaroon = m.deserializeBinary(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe/A=='));
   t.equal(macaroon._location, 'http://example.org/');
   t.equal(macaroon._identifier, 'keyid');
   t.equal(macaroon._caveats.length, 2);
   t.equal(macaroon._caveats[0]._identifier, 'account = 3735928559');
   t.equal(macaroon._caveats[1]._identifier, 'user = alice');
-  t.ok(Buffer.from(sjcl.codec.base64.fromBits(macaroon._signature), 'base64').equals(Buffer.from('S+lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw=', 'base64')));
+  t.equal(bytesToBase64(macaroon.signature), 'S+lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw=');
   t.end();
 });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const m = require('../macaroon');
-
+const base64 = require('base64-js');
 const nacl = require('tweetnacl');
 nacl.util = require('tweetnacl-util');
 
@@ -21,6 +21,17 @@ module.exports.Uint8ArrayToHex = ua => {
 
 module.exports.never = () => 'condition is never true';
 
+module.exports.base64ToBytes = s => {
+  return base64.toByteArray(s);
+};
+
+module.exports.bytesToBase64 = bytes => {
+  return base64.fromByteArray(bytes);
+};
+
+module.exports.bytes = a => {
+  return new Uint8Array(a);
+};
 
 /**
   Make a set of macaroons from the given macaroon spec.

--- a/test/test.js
+++ b/test/test.js
@@ -6,3 +6,5 @@ require('./verify');
 require('./discharge');
 require('./serialize-binary');
 require('./serialize-json');
+require('./internal');
+


### PR DESCRIPTION
We avoid the use of Buffer (because it's Node-specific)
and use our own varint implementation which is will
probably be a little faster because it doesn't need to work
with >32bit numbers.

There's still some use of Buffer in the JSON serialization code,
but leaving that for a subsequent PR.