### PR TITLE
rename import/export methods

### DIFF
--- a/test/import-export.js
+++ b/test/import-export.js
@@ -5,7 +5,7 @@ const test = require('tape');
 const m = require('../macaroon');
 const testUtils = require('./test-utils');
 
-test('should import from a single object', t => {
+test('importMacaroon should import from a single object', t => {
   const obj = {
     location: 'a location',
     identifier: 'id 1',
@@ -21,19 +21,19 @@ test('should import from a single object', t => {
     ],
   };
 
-  const macaroon = m.importFromJSONObject(obj);
+  const macaroon = m.importMacaroon(obj);
   t.equal(macaroon.location, 'a location');
   t.equal(testUtils.bytesToString(macaroon.identifier), 'id 1');
   t.equal(
     testUtils.bytesToHex(macaroon.signature),
     'e0831c334c600631bf7b860ca20c9930f584b077b8eac1f1e99c6a45d11a3d20');
   // Test that it round trips.
-  const obj1 = macaroon.exportAsJSONObject();
+  const obj1 = macaroon.exportJSON();
   t.deepEqual(obj1, obj);
   t.end();
 });
 
-test('should import from an array', t => {
+test('importMacaroons should import from an array', t => {
   const objs = [{
     location: 'a location',
     identifier: 'id 0',
@@ -43,14 +43,14 @@ test('should import from an array', t => {
     identifier: 'id 1',
     signature: '99b1c2dede0ce1cba0b632e3996e9924bdaee6287151600468644b92caf3761b',
   }];
-  const macaroon = m.importFromJSONObject(objs);
+  const macaroon = m.importMacaroons(objs);
 
   t.equal(macaroon.length, 2);
   t.equal(testUtils.bytesToString(macaroon[0].identifier), 'id 0');
   t.equal(testUtils.bytesToString(macaroon[1].identifier), 'id 1');
 
   t.deepEqual([
-    macaroon[0].exportAsJSONObject(),
-    macaroon[1].exportAsJSONObject()], objs);
+    macaroon[0].exportJSON(),
+    macaroon[1].exportJSON()], objs);
   t.end();
 });

--- a/test/macaroon.js
+++ b/test/macaroon.js
@@ -18,7 +18,7 @@ test('should be created with the expected signature', t => {
     testUtils.bytesToHex(macaroon.signature),
     'd916ce6f9b62dc4a080ce5d4a660956471f19b860da4242b0852727331c1033d');
 
-  const obj = macaroon.exportAsJSONObject();
+  const obj = macaroon.exportJSON();
   t.deepEqual(obj, {
     location: 'a location',
     identifier: 'some id',
@@ -95,7 +95,7 @@ test('should allow adding first party caveats', t => {
   t.equal(
     testUtils.bytesToHex(macaroon.signature),
     'c934e6af642ee55a4e4cfc56e07706cf1c6c94dc2192e5582943cddd88dc99d8');
-  const obj = macaroon.exportAsJSONObject();
+  const obj = macaroon.exportJSON();
   t.deepEqual(obj, {
     location: 'a location',
     identifier: 'some id',

--- a/test/serialize-binary.js
+++ b/test/serialize-binary.js
@@ -15,7 +15,7 @@ test('should serialize binary format without caveats', t => {
     location: 'http://example.org/'
   });
 
-  t.equal(bytesToBase64(macaroon.serializeBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc');
+  t.equal(bytesToBase64(macaroon.exportBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc');
   t.end();
 });
 
@@ -26,7 +26,7 @@ test('should serialize binary format with one caveat', t => {
     location: 'http://example.org/'
   });
   macaroon.addFirstPartyCaveat('account = 3735928559');
-  t.equal(bytesToBase64(macaroon.serializeBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw');
+  t.equal(bytesToBase64(macaroon.exportBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw');
   t.end();
 });
 
@@ -39,12 +39,12 @@ test('should serialize binary format with two caveats', t => {
   macaroon.addFirstPartyCaveat('account = 3735928559');
   macaroon.addFirstPartyCaveat('user = alice');
 
-  t.equal(bytesToBase64(macaroon.serializeBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe_A');
+  t.equal(bytesToBase64(macaroon.exportBinary()), 'AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe_A');
   t.end();
 });
 
 test('should deserialize binary format without caveats', t => {
-  const macaroon = m.deserializeBinary(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc='));
+  const macaroon = m.importMacaroon(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd/psk54XijiqZMB+dcRxgnjjvc='));
   t.equal(macaroon.location, 'http://example.org/');
   t.equal(testUtils.bytesToString(macaroon.identifier), 'keyid');
   t.equal(macaroon.caveats.length, 0);
@@ -53,7 +53,17 @@ test('should deserialize binary format without caveats', t => {
 });
 
 test('should deserialize binary format with one caveat', t => {
-  const macaroon = m.deserializeBinary(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw=='));
+  const macaroon = m.importMacaroon(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw=='));
+  t.equal(macaroon.location, 'http://example.org/');
+  t.equal(testUtils.bytesToString(macaroon.identifier), 'keyid');
+  t.equal(macaroon.caveats.length, 1);
+  t.equal(testUtils.bytesToString(macaroon.caveats[0].identifier), 'account = 3735928559');
+  t.equal(bytesToBase64(macaroon.signature), '9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc');
+  t.end();
+});
+
+test('should import from base64 string', t => {
+  const macaroon = m.importMacaroon('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw==');
   t.equal(macaroon.location, 'http://example.org/');
   t.equal(testUtils.bytesToString(macaroon.identifier), 'keyid');
   t.equal(macaroon.caveats.length, 1);
@@ -63,7 +73,7 @@ test('should deserialize binary format with one caveat', t => {
 });
 
 test('should deserialize binary format with two caveats', t => {
-  const macaroon = m.deserializeBinary(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe/A=='));
+  const macaroon = m.importMacaroon(base64ToBytes('AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe/A=='));
   t.equal(macaroon.location, 'http://example.org/');
   t.equal(testUtils.bytesToString(macaroon.identifier), 'keyid');
   const caveats = macaroon.caveats;

--- a/test/serialize-json.js
+++ b/test/serialize-json.js
@@ -12,7 +12,7 @@ test('should serialize json format without caveats', t => {
     location: 'http://example.org/'
   });
 
-  t.deepEqual(macaroon.exportAsJSONObject(), {'v':2,'l':'http://example.org/','i':'keyid','s64':'fN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc'});
+  t.deepEqual(macaroon.exportJSON(), {'v':2,'l':'http://example.org/','i':'keyid','s64':'fN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc'});
   t.end();
 });
 
@@ -24,7 +24,7 @@ test('should serialize json format with one caveat', t => {
   });
   macaroon.addFirstPartyCaveat('account = 3735928559');
 
-  t.deepEqual(macaroon.exportAsJSONObject(), {'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'}],'s64':'9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc'});
+  t.deepEqual(macaroon.exportJSON(), {'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'}],'s64':'9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc'});
   t.end();
 });
 
@@ -37,12 +37,12 @@ test('should serialize json format with two caveats', t => {
   macaroon.addFirstPartyCaveat('account = 3735928559');
   macaroon.addFirstPartyCaveat('user = alice');
 
-  t.deepEqual(macaroon.exportAsJSONObject(), {'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'},{'i':'user = alice'}],'s64':'S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw'});
+  t.deepEqual(macaroon.exportJSON(), {'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'},{'i':'user = alice'}],'s64':'S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw'});
   t.end();
 });
 
 test('should deserialize json format without caveats', t => {
-  const macaroon = m.importFromJSONObject({'v':2,'l':'http://example.org/','i':'keyid','c':[],'s64':'fN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc'});
+  const macaroon = m.importMacaroon({'v':2,'l':'http://example.org/','i':'keyid','c':[],'s64':'fN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc'});
   t.equal(macaroon.location, 'http://example.org/');
   t.equal(testUtils.bytesToString(macaroon.identifier), 'keyid');
   t.equal(macaroon.caveats.length, 0);
@@ -51,7 +51,7 @@ test('should deserialize json format without caveats', t => {
 });
 
 test('should deserialize json format with one caveat', t => {
-  const macaroon = m.importFromJSONObject({'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'}],'s64':'9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc'});
+  const macaroon = m.importMacaroon({'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'}],'s64':'9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc'});
   t.equal(macaroon.location, 'http://example.org/');
   t.equal(testUtils.bytesToString(macaroon.identifier), 'keyid');
   const caveats = macaroon.caveats;
@@ -62,7 +62,7 @@ test('should deserialize json format with one caveat', t => {
 });
 
 test('should deserialize json format with two caveats', t => {
-  const macaroon = m.importFromJSONObject({'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'},{'i':'user = alice'}],'s64':'S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw'});
+  const macaroon = m.importMacaroon({'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'},{'i':'user = alice'}],'s64':'S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw'});
   t.equal(macaroon.location, 'http://example.org/');
   t.equal(testUtils.bytesToString(macaroon.identifier), 'keyid');
   const caveats = macaroon.caveats;

--- a/test/verify.js
+++ b/test/verify.js
@@ -446,7 +446,7 @@ const externalMacaroons = [
 ];
 
 test('should verify external third party macaroons correctly', t => {
-  const ms = m.importFromJSONObject(externalMacaroons);
+  const ms = m.importMacaroons(externalMacaroons);
   ms[0].verify(externalRootKey, () => {}, ms.slice(1));
   t.end();
 });


### PR DESCRIPTION
We make the following changes in the interests of conciseness,
consistency and clarity.

exportToJSONObject becomes exportJSON.
serializeBinary becomes exportBinary.
importMacaroon replaces importFromJSONObject and deserializeBinary but always imports a single macaroon only.
importMacaroons also replaces importFromJSONObject and deserializeBinary but alwaus imports an array of macaroons (it also allows import of a single macaroon, even though it always returns an array).