### PR TITLE
Use util.TextEncoder when window.TextEncoder is not present.

### DIFF
--- a/macaroon.js
+++ b/macaroon.js
@@ -17,7 +17,7 @@ const nacl = require('tweetnacl');
 const naclutil = require('tweetnacl-util');
 
 let TextEncoder, TextDecoder;
-if (window && window.TextEncoder) {
+if (typeof window !== 'undefined' && window && window.TextEncoder) {
   TextEncoder = window.TextEncoder;
   TextDecoder = window.TextDecoder;
 } else {
@@ -1116,8 +1116,8 @@ const newMacaroon = function({identifier, location, rootKey, version} = {}) {
     identifierBytes: identifierBytes,
     locationStr: maybeString(location, 'Macaroon location'),
     signatureBytes: bitsToBytes(keyedHash(
-        makeKey(bytesToBits(rootKeyBytes)),
-        bytesToBits(identifierBytes))),
+      makeKey(bytesToBits(rootKeyBytes)),
+      bytesToBits(identifierBytes))),
   });
 };
 

--- a/macaroon.js
+++ b/macaroon.js
@@ -17,14 +17,14 @@ const nacl = require('tweetnacl');
 const naclutil = require('tweetnacl-util');
 
 let TextEncoder, TextDecoder;
-if (typeof window === 'undefined') {
-  // No window if it's node.js.
+if (window && window.TextEncoder) {
+  TextEncoder = window.TextEncoder;
+  TextDecoder = window.TextDecoder;
+} else {
+  // No window.TextEncoder if it's node.js.
   const util = require('util');
   TextEncoder = util.TextEncoder;
   TextDecoder = util.TextDecoder;
-} else {
-  TextEncoder = window.TextEncoder;
-  TextDecoder = window.TextDecoder;
 }
 
 const utf8Encoder = new TextEncoder();


### PR DESCRIPTION
Some js test environments such as Jest provide a window object, but *not* TextEncoder, which results in TextEncoder being `undefined` and never set to `util.TextEncoder`.

e.g.
```
TypeError: TextEncoder is not a constructor

    > 1 | import { Bakery, BakeryStorage } from "macaroon-bakery";
        | ^
      2 |
      3 | // Initialise Macaroon Bakery singleton
      4 | const visit = error => {

      at Object.<anonymous> (node_modules/macaroon/macaroon.js:19:21)
      at Object.<anonymous> (node_modules/macaroon-bakery/index.js:5:21)
      at Object.<anonymous> (src/bakery.js:1:1)
```

 `npm run check` appears to fail, but not due to my change:
```
/Users/kit/src/canonical/js-macaroon/macaroon.js
  1119:1  error  Expected indentation of 6 spaces but found 8  indent
  1120:1  error  Expected indentation of 6 spaces but found 8  indent
```