### PR TITLE
Add null check to decrypt response

### DIFF
--- a/macaroon.js
+++ b/macaroon.js
@@ -505,7 +505,7 @@ const decrypt = function(keyBits, ciphertextBits) {
   const nonceBytes = ciphertextBytes.slice(0, NONCELEN);
   const dataBytes = ciphertextBytes.slice(NONCELEN);
   let textBytes = nacl.secretbox.open(dataBytes, nonceBytes, keyBytes);
-  if (textBytes === false) {
+  if (textBytes === false || textBytes === null) {
     throw new Error('decryption failed');
   }
   return bytesToBits(textBytes);

--- a/macaroon.js
+++ b/macaroon.js
@@ -505,7 +505,7 @@ const decrypt = function(keyBits, ciphertextBits) {
   const nonceBytes = ciphertextBytes.slice(0, NONCELEN);
   const dataBytes = ciphertextBytes.slice(NONCELEN);
   let textBytes = nacl.secretbox.open(dataBytes, nonceBytes, keyBytes);
-  if (textBytes === false || textBytes === null) {
+  if (!textBytes) {
     throw new Error('decryption failed');
   }
   return bytesToBits(textBytes);

--- a/test/verify.js
+++ b/test/verify.js
@@ -450,3 +450,12 @@ test('should verify external third party macaroons correctly', t => {
   ms[0].verify(externalRootKey, () => {}, ms.slice(1));
   t.end();
 });
+
+test('should handle incorrect root key correctly', t => {
+    const ms = m.importMacaroons(externalMacaroons);
+    t.throws(() => {
+        ms[0].verify('wrong-key', () => {}, ms.slice(1));
+    }, /decryption failed/, 'Should fail with decryption error');
+    t.end();
+});
+


### PR DESCRIPTION
When decryption fails due to an incorrect root key, the response from the `decrypt` function is null instead of false, this adds a check to ensure that the error is correctly thrown, otherwise the error comes from the downstream method and is less clear.