### PR TITLE
Importing a Macaroon with a missing version causes the import to fail.

### DIFF
--- a/macaroon.js
+++ b/macaroon.js
@@ -992,7 +992,7 @@ const importJSONV1 = function(obj) {
  * @returns {Macaroon}
 */
 const importJSONV2 = function(obj) {
-  if (obj.v !== 2) {
+  if (obj.v && obj.v !== 2) {
     throw new Error(`Unsupported macaroon version ${obj.v}`);
   }
   const params = {

--- a/test/serialize-json.js
+++ b/test/serialize-json.js
@@ -61,8 +61,15 @@ test('should deserialize json format with one caveat', t => {
   t.end();
 });
 
+test('should not deserialize json format with invalid version', t => {
+  t.throws(() => {
+    m.importMacaroon({'v':3,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'}],'s64':'9UgH9txu34i_D3MGs4IlYqNiUz2_czm6YXZdpL0lnYc'});
+  }, /Unsupported macaroon version/, "Should not deserialize with invalid version");
+t.end();
+});
+
 test('should deserialize json format with two caveats', t => {
-  const macaroon = m.importMacaroon({'v':2,'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'},{'i':'user = alice'}],'s64':'S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw'});
+  const macaroon = m.importMacaroon({'l':'http://example.org/','i':'keyid','c':[{'i':'account = 3735928559'},{'i':'user = alice'}],'s64':'S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw'});
   t.equal(macaroon.location, 'http://example.org/');
   t.equal(testUtils.bytesToString(macaroon.identifier), 'keyid');
   const caveats = macaroon.caveats;


### PR DESCRIPTION
Currently the `go-macaroon` library does not set the version field when exporting the V2 JSON format. This patch simply checks that if the field is not empty, that it's equal to 2. Otherwise, it fails.

A unit test has been added and `npm run test` passes.