### PR TITLE
[Bugfix] Avoid "RangeError: Invalid typed array length: 3355443200" when using more than 2 caveats

### DIFF
--- a/macaroon.js
+++ b/macaroon.js
@@ -118,16 +118,22 @@ const ByteBuffer = class ByteBuffer {
     return this._buf.subarray(0, this._length);
   }
   /**
-   * Grow the internal buffer so that it's at least as but as minCap.
+   * Grow the internal buffer so that it's at least as big as minCap.
    * @param {int} minCap The minimum new capacity.
    */
   _grow(minCap) {
-    if (minCap <= this._capacity) {
+    const capacity = this._buf.length;
+    if (minCap <= capacity) {
       return;
     }
-    // TODO could use more intelligent logic to grow more slowly on large buffers.
+    const fiftyPercent = Math.ceil(capacity * 1.5);
     const doubleCap = this._buf.length * 2;
-    const newCap = minCap > doubleCap ? minCap : doubleCap;
+    let newCap = minCap > doubleCap ? minCap : doubleCap;
+    // If the new capacity is only 1 to 9 bytes, try if increasing
+    // the buffer by 50% is enough.
+    if (minCap - capacity < 10 && minCap < fiftyPercent) {
+      newCap = fiftyPercent;
+    }
     const newContent = new Uint8Array(newCap);
     newContent.set(this._buf.subarray(0, this._length));
     this._buf = newContent;

--- a/test/bytebuffer.js
+++ b/test/bytebuffer.js
@@ -33,6 +33,15 @@ test('ByteBuffer append bytes', t => {
   t.end();
 });
 
+test('ByteBuffer append 256 bytes, verify growth not exponential', t => {
+  const buf = new ByteBuffer(0);
+  for(var i = 0; i < 256; i++) {
+    buf.appendByte(i);
+  }
+  t.equal(buf._buf.length, 365);
+  t.end();
+});
+
 test('ByteBuffer appendUvarint', t => {
   varintTests.forEach(test => {
     const buf = new ByteBuffer(0);

--- a/test/verify.js
+++ b/test/verify.js
@@ -452,10 +452,10 @@ test('should verify external third party macaroons correctly', t => {
 });
 
 test('should handle incorrect root key correctly', t => {
-    const ms = m.importMacaroons(externalMacaroons);
-    t.throws(() => {
-        ms[0].verify('wrong-key', () => {}, ms.slice(1));
-    }, /decryption failed/, 'Should fail with decryption error');
-    t.end();
+  const ms = m.importMacaroons(externalMacaroons);
+  t.throws(() => {
+    ms[0].verify('wrong-key', () => {}, ms.slice(1));
+  }, /decryption failed/, 'Should fail with decryption error');
+  t.end();
 });
 


### PR DESCRIPTION
I noticed that I get an error when using more than 2 caveats:
`RangeError: Invalid typed array length: 3355443200`

Then I found out that the problem is the `_grow` function of `ByteBuffer` that always doubles the buffer in size and therefore grows exponentially, even if just one byte is added to the buffer.

My PR fixes this issue as well as two pre-existing bugs (there was a variable `this._capacity` in `_grow` that wasn't defined any more and I had to format `test/verify.js` to make eslint happy).