### PR TITLE
use simpler buffer grow logic in ByteBuffer

### DIFF
--- a/macaroon.js
+++ b/macaroon.js
@@ -122,18 +122,12 @@ const ByteBuffer = class ByteBuffer {
    * @param {int} minCap The minimum new capacity.
    */
   _grow(minCap) {
-    const capacity = this._buf.length;
-    if (minCap <= capacity) {
+    if (minCap <= this._buf.length) {
       return;
     }
-    const fiftyPercent = Math.ceil(capacity * 1.5);
+    // TODO could use more intelligent logic to grow more slowly on large buffers.
     const doubleCap = this._buf.length * 2;
-    let newCap = minCap > doubleCap ? minCap : doubleCap;
-    // If the new capacity is only 1 to 9 bytes, try if increasing
-    // the buffer by 50% is enough.
-    if (minCap - capacity < 10 && minCap < fiftyPercent) {
-      newCap = fiftyPercent;
-    }
+    const newCap = minCap > doubleCap ? minCap : doubleCap;
     const newContent = new Uint8Array(newCap);
     newContent.set(this._buf.subarray(0, this._length));
     this._buf = newContent;

--- a/test/bytebuffer.js
+++ b/test/bytebuffer.js
@@ -38,7 +38,7 @@ test('ByteBuffer append 256 bytes, verify growth not exponential', t => {
   for(var i = 0; i < 256; i++) {
     buf.appendByte(i);
   }
-  t.equal(buf._buf.length, 365);
+  t.equal(buf._buf.length, 256);
   t.end();
 });
 


### PR DESCRIPTION
Growing by a factor of two is good when the buffer is small,
which it invariably is with macaroons. This makes the logic
a bit more understandable IMHO.
